### PR TITLE
Added fluent-behaviour-tree library

### DIFF
--- a/Assets/Scripts/BehaviorTree.meta
+++ b/Assets/Scripts/BehaviorTree.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 369c571f193433c4b910ad15c28b27df
+folderAsset: yes
+timeCreated: 1518049753
+licenseType: Free
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/BehaviorTree/SampleBehaviorTree.cs
+++ b/Assets/Scripts/BehaviorTree/SampleBehaviorTree.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using FluentBehaviourTree;
+
+public class SampleBehaviorTree : MonoBehaviour {
+
+    IBehaviourTreeNode tree;
+
+	void Start () {
+        var builder = new BehaviourTreeBuilder();
+        this.tree = builder
+            .Sequence("Sample-Sequence")
+            .Do("SampleAction1", t =>
+            {
+                Debug.Log("I am doing action 1!");
+                return BehaviourTreeStatus.Success;
+            })
+            .Do("SampleAction2", tree =>
+            {
+                Debug.Log("I am doing the second action!");
+                return BehaviourTreeStatus.Success;
+            })
+            .End()
+            .Build();
+	}
+	
+	void Update () {
+        this.tree.Tick(new TimeData(100000));
+	}
+}

--- a/Assets/Scripts/BehaviorTree/SampleBehaviorTree.cs.meta
+++ b/Assets/Scripts/BehaviorTree/SampleBehaviorTree.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 72950630ffc3e644aa0133a0e13b3c29
+timeCreated: 1518050229
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/FluentBehaviourTree_Library.meta
+++ b/Assets/Scripts/FluentBehaviourTree_Library.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: b151205bd7c71f9418afd4a6cd23421c
+folderAsset: yes
+timeCreated: 1518051921
+licenseType: Free
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/FluentBehaviourTree_Library/src.meta
+++ b/Assets/Scripts/FluentBehaviourTree_Library/src.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: d88ce59f95eeed244b900fa4d755ce3c
+folderAsset: yes
+timeCreated: 1518051921
+licenseType: Free
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/FluentBehaviourTree_Library/src/BehaviourTreeBuilder.cs
+++ b/Assets/Scripts/FluentBehaviourTree_Library/src/BehaviourTreeBuilder.cs
@@ -1,0 +1,150 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace FluentBehaviourTree
+{
+    /// <summary>
+    /// Fluent API for building a behaviour tree.
+    /// </summary>
+    public class BehaviourTreeBuilder
+    {
+        /// <summary>
+        /// Last node created.
+        /// </summary>
+        private IBehaviourTreeNode curNode = null;
+
+        /// <summary>
+        /// Stack node nodes that we are build via the fluent API.
+        /// </summary>
+        private Stack<IParentBehaviourTreeNode> parentNodeStack = new Stack<IParentBehaviourTreeNode>();
+
+        /// <summary>
+        /// Create an action node.
+        /// </summary>
+        public BehaviourTreeBuilder Do(string name, Func<TimeData, BehaviourTreeStatus> fn)
+        {
+            if (parentNodeStack.Count <= 0)
+            {
+                throw new ApplicationException("Can't create an unnested ActionNode, it must be a leaf node.");
+            }
+
+            var actionNode = new ActionNode(name, fn);
+            parentNodeStack.Peek().AddChild(actionNode);
+            return this;
+        }
+
+        /// <summary>
+        /// Like an action node... but the function can return true/false and is mapped to success/failure.
+        /// </summary>
+        public BehaviourTreeBuilder Condition(string name, Func<TimeData, bool> fn)
+        {
+            return Do(name, t => fn(t) ? BehaviourTreeStatus.Success : BehaviourTreeStatus.Failure);
+        }
+
+        /// <summary>
+        /// Create an inverter node that inverts the success/failure of its children.
+        /// </summary>
+        public BehaviourTreeBuilder Inverter(string name)
+        {
+            var inverterNode = new InverterNode(name);
+
+            if (parentNodeStack.Count > 0)
+            {
+                parentNodeStack.Peek().AddChild(inverterNode);
+            }
+
+            parentNodeStack.Push(inverterNode);
+            return this;
+        }
+
+        /// <summary>
+        /// Create a sequence node.
+        /// </summary>
+        public BehaviourTreeBuilder Sequence(string name)
+        {
+            var sequenceNode = new SequenceNode(name);
+
+            if (parentNodeStack.Count > 0)
+            {
+                parentNodeStack.Peek().AddChild(sequenceNode);
+            }
+
+            parentNodeStack.Push(sequenceNode);
+            return this;
+        }
+
+        /// <summary>
+        /// Create a parallel node.
+        /// </summary>
+        public BehaviourTreeBuilder Parallel(string name, int numRequiredToFail, int numRequiredToSucceed)
+        {
+            var parallelNode = new ParallelNode(name, numRequiredToFail, numRequiredToSucceed);
+
+            if (parentNodeStack.Count > 0)
+            {
+                parentNodeStack.Peek().AddChild(parallelNode);
+            }
+
+            parentNodeStack.Push(parallelNode);
+            return this;
+        }
+
+        /// <summary>
+        /// Create a selector node.
+        /// </summary>
+        public BehaviourTreeBuilder Selector(string name)
+        {
+            var selectorNode = new SelectorNode(name);
+
+            if (parentNodeStack.Count > 0)
+            {
+                parentNodeStack.Peek().AddChild(selectorNode);
+            }
+
+            parentNodeStack.Push(selectorNode);
+            return this;
+        }
+
+        /// <summary>
+        /// Splice a sub tree into the parent tree.
+        /// </summary>
+        public BehaviourTreeBuilder Splice(IBehaviourTreeNode subTree)
+        {
+            if (subTree == null)
+            {
+                throw new ArgumentNullException("subTree");
+            }
+
+            if (parentNodeStack.Count <= 0)
+            {
+                throw new ApplicationException("Can't splice an unnested sub-tree, there must be a parent-tree.");
+            }
+
+            parentNodeStack.Peek().AddChild(subTree);
+            return this;
+        }
+
+        /// <summary>
+        /// Build the actual tree.
+        /// </summary>
+        public IBehaviourTreeNode Build()
+        {
+            if (curNode == null)
+            {
+                throw new ApplicationException("Can't create a behaviour tree with zero nodes");
+            }
+            return curNode;
+        }
+
+        /// <summary>
+        /// Ends a sequence of children.
+        /// </summary>
+        public BehaviourTreeBuilder End()
+        {
+            curNode = parentNodeStack.Pop();
+            return this;
+        }
+    }
+}

--- a/Assets/Scripts/FluentBehaviourTree_Library/src/BehaviourTreeBuilder.cs.meta
+++ b/Assets/Scripts/FluentBehaviourTree_Library/src/BehaviourTreeBuilder.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: c1d978f277a5527469a08a0a47095123
+timeCreated: 1518051944
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/FluentBehaviourTree_Library/src/BehaviourTreeStatus.cs
+++ b/Assets/Scripts/FluentBehaviourTree_Library/src/BehaviourTreeStatus.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace FluentBehaviourTree
+{
+    /// <summary>
+    /// The return type when invoking behaviour tree nodes.
+    /// </summary>
+    public enum BehaviourTreeStatus
+    {
+        Success,
+        Failure,
+        Running
+    }
+}

--- a/Assets/Scripts/FluentBehaviourTree_Library/src/BehaviourTreeStatus.cs.meta
+++ b/Assets/Scripts/FluentBehaviourTree_Library/src/BehaviourTreeStatus.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: de94af19424ba3f4cb2e8eaefa27cd22
+timeCreated: 1518051944
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/FluentBehaviourTree_Library/src/Fluent-Behaviour-Tree.nuspec
+++ b/Assets/Scripts/FluentBehaviourTree_Library/src/Fluent-Behaviour-Tree.nuspec
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>$id$</id>
+    <version>$version$</version>
+    <title>$title$</title>
+    <authors>$author$</authors>
+    <owners>$author$</owners>
+    <licenseUrl>https://github.com/codecapers/Fluent-Behaviour-Tree</licenseUrl>
+    <projectUrl>https://github.com/codecapers/Fluent-Behaviour-Tree</projectUrl>
+    <iconUrl>https://avatars1.githubusercontent.com/u/8173836?v=3&amp;s=200</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>$description$</description>
+    <releaseNotes></releaseNotes>
+    <copyright>Copyright 2015</copyright>
+    <tags>C# fluent api behaviour behavior tree</tags>
+  </metadata>
+</package>

--- a/Assets/Scripts/FluentBehaviourTree_Library/src/Fluent-Behaviour-Tree.nuspec.meta
+++ b/Assets/Scripts/FluentBehaviourTree_Library/src/Fluent-Behaviour-Tree.nuspec.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 7cdf207f1f92a8a4b962f7ccb0b92104
+timeCreated: 1518051921
+licenseType: Free
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/FluentBehaviourTree_Library/src/IBehaviourTreeNode.cs
+++ b/Assets/Scripts/FluentBehaviourTree_Library/src/IBehaviourTreeNode.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace FluentBehaviourTree
+{
+    /// <summary>
+    /// Interface for behaviour tree nodes.
+    /// </summary>
+    public interface IBehaviourTreeNode
+    {
+        /// <summary>
+        /// Update the time of the behaviour tree.
+        /// </summary>
+        BehaviourTreeStatus Tick(TimeData time);
+    }
+}

--- a/Assets/Scripts/FluentBehaviourTree_Library/src/IBehaviourTreeNode.cs.meta
+++ b/Assets/Scripts/FluentBehaviourTree_Library/src/IBehaviourTreeNode.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: d66ba82df99789d459fd89ba5ab1e75e
+timeCreated: 1518051944
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/FluentBehaviourTree_Library/src/IParentBehaviourTreeNode.cs
+++ b/Assets/Scripts/FluentBehaviourTree_Library/src/IParentBehaviourTreeNode.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace FluentBehaviourTree
+{
+    /// <summary>
+    /// Interface for behaviour tree nodes.
+    /// </summary>
+    public interface IParentBehaviourTreeNode : IBehaviourTreeNode
+    {
+        /// <summary>
+        /// Add a child to the parent node.
+        /// </summary>
+        void AddChild(IBehaviourTreeNode child);
+    }
+}

--- a/Assets/Scripts/FluentBehaviourTree_Library/src/IParentBehaviourTreeNode.cs.meta
+++ b/Assets/Scripts/FluentBehaviourTree_Library/src/IParentBehaviourTreeNode.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: e21a39979b83fc84ea6fd739d9bd7788
+timeCreated: 1518051944
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/FluentBehaviourTree_Library/src/Nodes.meta
+++ b/Assets/Scripts/FluentBehaviourTree_Library/src/Nodes.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 52e433b9adc04ea469a2087a0bf99b5f
+folderAsset: yes
+timeCreated: 1518051921
+licenseType: Free
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/FluentBehaviourTree_Library/src/Nodes/ActionNode.cs
+++ b/Assets/Scripts/FluentBehaviourTree_Library/src/Nodes/ActionNode.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace FluentBehaviourTree
+{
+    /// <summary>
+    /// A behaviour tree leaf node for running an action.
+    /// </summary>
+    public class ActionNode : IBehaviourTreeNode
+    {
+        /// <summary>
+        /// The name of the node.
+        /// </summary>
+        private string name;
+
+        /// <summary>
+        /// Function to invoke for the action.
+        /// </summary>
+        private Func<TimeData, BehaviourTreeStatus> fn;
+        
+
+        public ActionNode(string name, Func<TimeData, BehaviourTreeStatus> fn)
+        {
+            this.name=name;
+            this.fn=fn;
+        }
+
+        public BehaviourTreeStatus Tick(TimeData time)
+        {
+            return fn(time);
+        }
+    }
+}

--- a/Assets/Scripts/FluentBehaviourTree_Library/src/Nodes/ActionNode.cs.meta
+++ b/Assets/Scripts/FluentBehaviourTree_Library/src/Nodes/ActionNode.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 9710b427cf24b2343a0eef6212e723b2
+timeCreated: 1518051944
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/FluentBehaviourTree_Library/src/Nodes/InverterNode.cs
+++ b/Assets/Scripts/FluentBehaviourTree_Library/src/Nodes/InverterNode.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace FluentBehaviourTree
+{
+    /// <summary>
+    /// Decorator node that inverts the success/failure of its child.
+    /// </summary>
+    public class InverterNode : IParentBehaviourTreeNode
+    {
+        /// <summary>
+        /// Name of the node.
+        /// </summary>
+        private string name;
+
+        /// <summary>
+        /// The child to be inverted.
+        /// </summary>
+        private IBehaviourTreeNode childNode;
+
+        public InverterNode(string name)
+        {
+            this.name = name;
+        }
+
+        public BehaviourTreeStatus Tick(TimeData time)
+        {
+            if (childNode == null)
+            {
+                throw new ApplicationException("InverterNode must have a child node!");
+            }
+
+            var result = childNode.Tick(time);
+            if (result == BehaviourTreeStatus.Failure)
+            {
+                return BehaviourTreeStatus.Success;
+            }
+            else if (result == BehaviourTreeStatus.Success)
+            {
+                return BehaviourTreeStatus.Failure;
+            }
+            else
+            {
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Add a child to the parent node.
+        /// </summary>
+        public void AddChild(IBehaviourTreeNode child)
+        {
+            if (this.childNode != null)
+            {
+                throw new ApplicationException("Can't add more than a single child to InverterNode!");
+            }
+
+            this.childNode = child;
+        }
+    }
+}

--- a/Assets/Scripts/FluentBehaviourTree_Library/src/Nodes/InverterNode.cs.meta
+++ b/Assets/Scripts/FluentBehaviourTree_Library/src/Nodes/InverterNode.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 2b8a1cdb4e21f2e4cb3a3b64900b4569
+timeCreated: 1518051944
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/FluentBehaviourTree_Library/src/Nodes/ParallelNode.cs
+++ b/Assets/Scripts/FluentBehaviourTree_Library/src/Nodes/ParallelNode.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace FluentBehaviourTree
+{
+    /// <summary>
+    /// Runs childs nodes in parallel.
+    /// </summary>
+    public class ParallelNode : IParentBehaviourTreeNode
+    {
+        /// <summary>
+        /// Name of the node.
+        /// </summary>
+        private string name;
+
+        /// <summary>
+        /// List of child nodes.
+        /// </summary>
+        private List<IBehaviourTreeNode> children = new List<IBehaviourTreeNode>();
+
+        /// <summary>
+        /// Number of child failures required to terminate with failure.
+        /// </summary>
+        private int numRequiredToFail;
+
+        /// <summary>
+        /// Number of child successess require to terminate with success.
+        /// </summary>
+        private int numRequiredToSucceed;
+
+        public ParallelNode(string name, int numRequiredToFail, int numRequiredToSucceed)
+        {
+            this.name = name;
+            this.numRequiredToFail = numRequiredToFail;
+            this.numRequiredToSucceed = numRequiredToSucceed;
+        }
+
+        public BehaviourTreeStatus Tick(TimeData time)
+        {
+            var numChildrenSuceeded = 0;
+            var numChildrenFailed = 0;
+
+            foreach (var child in children)
+            {
+                var childStatus = child.Tick(time);
+                switch (childStatus)
+                {
+                    case BehaviourTreeStatus.Success: ++numChildrenSuceeded; break;
+                    case BehaviourTreeStatus.Failure: ++numChildrenFailed; break;
+                }
+            }
+
+            if (numRequiredToSucceed > 0 && numChildrenSuceeded >= numRequiredToSucceed)
+            {
+                return BehaviourTreeStatus.Success;
+            }
+
+            if (numRequiredToFail > 0 && numChildrenFailed >= numRequiredToFail)
+            {
+                return BehaviourTreeStatus.Failure;
+            }
+
+            return BehaviourTreeStatus.Running;
+        }
+
+        public void AddChild(IBehaviourTreeNode child)
+        {
+            children.Add(child);
+        }
+    }
+}

--- a/Assets/Scripts/FluentBehaviourTree_Library/src/Nodes/ParallelNode.cs.meta
+++ b/Assets/Scripts/FluentBehaviourTree_Library/src/Nodes/ParallelNode.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: eb983d3d9f8e4024b8b2bc697f9542c6
+timeCreated: 1518051944
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/FluentBehaviourTree_Library/src/Nodes/SelectorNode.cs
+++ b/Assets/Scripts/FluentBehaviourTree_Library/src/Nodes/SelectorNode.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace FluentBehaviourTree
+{
+    /// <summary>
+    /// Selects the first node that succeeds. Tries successive nodes until it finds one that doesn't fail.
+    /// </summary>
+    public class SelectorNode : IParentBehaviourTreeNode
+    {
+        /// <summary>
+        /// The name of the node.
+        /// </summary>
+        private string name;
+
+        /// <summary>
+        /// List of child nodes.
+        /// </summary>
+        private List<IBehaviourTreeNode> children = new List<IBehaviourTreeNode>(); //todo: optimization, bake this to an array.
+
+        public SelectorNode(string name)
+        {
+            this.name = name;
+        }
+
+        public BehaviourTreeStatus Tick(TimeData time)
+        {
+            foreach (var child in children)
+            {
+                var childStatus = child.Tick(time);
+                if (childStatus != BehaviourTreeStatus.Failure)
+                {
+                    return childStatus;
+                }
+            }
+
+            return BehaviourTreeStatus.Failure;
+        }
+
+        /// <summary>
+        /// Add a child node to the selector.
+        /// </summary>
+        public void AddChild(IBehaviourTreeNode child)
+        {
+            children.Add(child);
+        }
+    }
+}

--- a/Assets/Scripts/FluentBehaviourTree_Library/src/Nodes/SelectorNode.cs.meta
+++ b/Assets/Scripts/FluentBehaviourTree_Library/src/Nodes/SelectorNode.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 04ea155d83fc72149b7af55f6f05a739
+timeCreated: 1518051943
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/FluentBehaviourTree_Library/src/Nodes/SequenceNode.cs
+++ b/Assets/Scripts/FluentBehaviourTree_Library/src/Nodes/SequenceNode.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace FluentBehaviourTree
+{
+    /// <summary>
+    /// Runs child nodes in sequence, until one fails.
+    /// </summary>
+    public class SequenceNode : IParentBehaviourTreeNode
+    {
+        /// <summary>
+        /// Name of the node.
+        /// </summary>
+        private string name;
+
+        /// <summary>
+        /// List of child nodes.
+        /// </summary>
+        private List<IBehaviourTreeNode> children = new List<IBehaviourTreeNode>(); //todo: this could be optimized as a baked array.
+
+        public SequenceNode(string name)
+        {
+            this.name = name;
+        }
+
+        public BehaviourTreeStatus Tick(TimeData time)
+        {
+            foreach (var child in children)
+            {
+                var childStatus = child.Tick(time);
+                if (childStatus != BehaviourTreeStatus.Success)
+                {
+                    return childStatus;
+                }
+            }
+
+            return BehaviourTreeStatus.Success;
+        }
+
+        /// <summary>
+        /// Add a child to the sequence.
+        /// </summary>
+        public void AddChild(IBehaviourTreeNode child)
+        {
+            children.Add(child);
+        }
+    }
+}

--- a/Assets/Scripts/FluentBehaviourTree_Library/src/Nodes/SequenceNode.cs.meta
+++ b/Assets/Scripts/FluentBehaviourTree_Library/src/Nodes/SequenceNode.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 1a938bed71a75134dac5090136cb2244
+timeCreated: 1518051944
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/FluentBehaviourTree_Library/src/Properties.meta
+++ b/Assets/Scripts/FluentBehaviourTree_Library/src/Properties.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 9f7277c64f494764383bd0e78e99a954
+folderAsset: yes
+timeCreated: 1518051921
+licenseType: Free
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/FluentBehaviourTree_Library/src/Properties/AssemblyInfo.cs
+++ b/Assets/Scripts/FluentBehaviourTree_Library/src/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Fluent-Behaviour-Tree")]
+[assembly: AssemblyDescription("C# behaviour tree library with a fluent API")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Code Capers")]
+[assembly: AssemblyProduct("Fluent-Behaviour-Tree")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("41e64a25-7890-4edd-b405-d907badcf7ee")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("0.0.4.0")]
+[assembly: AssemblyFileVersion("0.0.4.0")]

--- a/Assets/Scripts/FluentBehaviourTree_Library/src/Properties/AssemblyInfo.cs.meta
+++ b/Assets/Scripts/FluentBehaviourTree_Library/src/Properties/AssemblyInfo.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 1338242a9136b9b4ca544670aa16004a
+timeCreated: 1518051944
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/FluentBehaviourTree_Library/src/TimeData.cs
+++ b/Assets/Scripts/FluentBehaviourTree_Library/src/TimeData.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace FluentBehaviourTree
+{
+    /// <summary>
+    /// Represents time. Used to pass time values to behaviour tree nodes.
+    /// </summary>
+    public struct TimeData
+    {
+        public TimeData(float deltaTime)
+        {
+            this.deltaTime = deltaTime;
+        }
+
+        public float deltaTime;
+    }
+}

--- a/Assets/Scripts/FluentBehaviourTree_Library/src/TimeData.cs.meta
+++ b/Assets/Scripts/FluentBehaviourTree_Library/src/TimeData.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: c14e5c43b01e70545bd0996dc5e37d1d
+timeCreated: 1518051944
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/FluentBehaviourTree_Library/src/fluent-behaviour-tree.csproj.meta
+++ b/Assets/Scripts/FluentBehaviourTree_Library/src/fluent-behaviour-tree.csproj.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: b3033dec560883145aac896e365263a2
+timeCreated: 1518051921
+licenseType: Free
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/FluentBehaviourTree_Library/src/fluent-behaviour-tree.sln.meta
+++ b/Assets/Scripts/FluentBehaviourTree_Library/src/fluent-behaviour-tree.sln.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 12b0cd6b999989e448fe742c76626037
+timeCreated: 1518051921
+licenseType: Free
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The fluent behaviour tree from [https://github.com/codecapers/Fluent-Behaviour-Tree](url) is what the Numinous people started with. I figured if the tools exist, we should use them. It isn't as pretty as a graphical representation like the tree view Josh and I made, but it does the same thing.